### PR TITLE
Feat: Adding query in appointment service

### DIFF
--- a/src/appointments/appointments.controller.ts
+++ b/src/appointments/appointments.controller.ts
@@ -93,4 +93,22 @@ export class AppointmentsController {
 
     return new AppointmentDTO(appointmentEntity);
   }
+
+  @Get('/next')
+  @UseInterceptors(ClassSerializerInterceptor)
+  @ApiOperation({ summary: 'Get Next Appointment' })
+  @ApiOkResponse({
+    description: 'The record has been successfully returned.',
+    type: AppointmentDTO,
+    isArray: false,
+  })
+  async getNextAppointment(
+    @GetCurrentUser() user: CurrentUserDTO,
+  ): Promise<AppointmentDTO> {
+    const { id } = user;
+
+    const appointmentEntity = await this.appointmentsService.getNext(id);
+
+    return new AppointmentDTO(appointmentEntity);
+  }
 }

--- a/src/appointments/appointments.service.ts
+++ b/src/appointments/appointments.service.ts
@@ -91,4 +91,19 @@ export class AppointmentsService {
       ...updateAppointmentDTO,
     });
   }
+
+  async getNext(id: string): Promise<AppointmentEntity> {
+    const nextAppointmentEntity = this.appointmentRepository
+      .createQueryBuilder('ap')
+      .innerJoin('service_periods', 'sp', 'ap.idServicePeriod = sp.id')
+      .where('ap.idUser = :id', { id: id })
+      .andWhere('ap.idAppointmentStatus = :status', {
+        status: APPOINTMENT_STATUS.PENDING,
+      })
+      .andWhere('ap.date >= now()')
+      .orderBy('ap.date', 'ASC')
+      .addOrderBy('sp.startTime', 'ASC')
+      .getOne();
+    return nextAppointmentEntity;
+  }
 }


### PR DESCRIPTION
## Tarefa(s)
- Exibição de próximo compromisso do USUÁRIO

## Descrição

Foi adicionado uma nova query para buscar o próximo agendamento com base na sua data e o horário mais próximos. 

## Evidências 
Endpoint retornando o appointment mais próximo:
![Screenshot from 2021-04-10 12-59-23](https://user-images.githubusercontent.com/7440528/114276390-ce7c6800-99fc-11eb-961e-360c18f86de1.png)

Podemos ver que o período mais próximo é o das 8 horas da manhã, e o que foi retornado foi justamente o serviço agendado com esse período:
![Screenshot from 2021-04-10 13-00-00](https://user-images.githubusercontent.com/7440528/114276391-cfad9500-99fc-11eb-9164-a90611e6f35d.png)

O agendamento com a data mais recente é o de21/04/2021 com está no retorno da request:
![Screenshot from 2021-04-10 13-00-43](https://user-images.githubusercontent.com/7440528/114276392-d0dec200-99fc-11eb-8417-a9d6e95f952a.png)


 
